### PR TITLE
テーブルのスタイルを修正

### DIFF
--- a/scss/component/blogs/main.scss
+++ b/scss/component/blogs/main.scss
@@ -93,7 +93,7 @@
 
   .post-table {
     width: 100%;
-    overflow: scroll;
+    overflow: auto;
   }
 
   table {
@@ -109,11 +109,28 @@
       font-weight: bold;
       padding: 10px 8px;
       border-bottom: 1px solid #4fbfa8;
+      
+      &[align="left"] {
+        text-align: left;
+      }
+      &[align="center"] {
+        text-align: center;
+      }
+      &[align="right"] {
+        text-align: right;
+      }
     }
 
     td {
-      padding: 10px 8px 3px;
+      padding: 10px 8px 3px 12px;
       white-space: nowrap;
+    }
+
+    tr>* {
+      border-right: 1px solid #4fbfa8;
+      &:last-child {
+        border-right: none;
+      }
     }
   }
 


### PR DESCRIPTION
## 変更点

- テーブルのスクロールバーが常に表示されているのを修正
- bootstrapの影響でテーブルのヘッダセルが常に左寄せになるのを修正
- テーブルに縦線を追加
  - それに伴いpaddingをちょっと調整
## 変更前

![2016-11-21 21 25 05](https://cloud.githubusercontent.com/assets/6602987/20482638/04a9ed54-b031-11e6-9708-86ff918e66ff.png)

## 変更後

![2016-11-21 21 23 18](https://cloud.githubusercontent.com/assets/6602987/20482616/e30551e8-b030-11e6-8cfd-714229a73978.png)

モバイル↓
![2016-11-21 21 23 35](https://cloud.githubusercontent.com/assets/6602987/20482617/e3065642-b030-11e6-8fc8-b6ce37c34a94.png)