### PR TITLE
デプロイ方法が適切でなかったので修正

### DIFF
--- a/docs/new-post.md
+++ b/docs/new-post.md
@@ -45,5 +45,8 @@ git push origin events/xxx
 #### 7) Github Pagesにデプロイ(この操作は管理者が実行する)
 
 ```
+cd pages
+git pull origin gh-pages # ローカルのブランチをリモートに合わせる
+cd ..
 ./deploy.sh "コミットメッセージ"
 ```


### PR DESCRIPTION
`./deply.sh`を実行するだけではpushできないことがあって、不適切だったので、ドキュメントを修正

```
cd pages
git pull origin gh-pages
cd ..
./deploy.sh
```

を実行する必要があった。
これも、シェルスクリプト化できると思うが、これはまた別PRで対応することにする。

https://gist.github.com/wokamoto/5342149
この辺りを参考に。

`git pull origin gh-pages`でもしコンフリクトを起こした場合など、シェルスクリプト内で対応する必要はあるので、いろいろと面倒くさそう。