### PR TITLE
タグとカテゴリを全件表示じゃなくした

### DIFF
--- a/layouts/partials/blogs/widgets/categories.html
+++ b/layouts/partials/blogs/widgets/categories.html
@@ -9,8 +9,8 @@
 
     <div class="panel-body">
         <ul class="nav nav-pills nav-stacked">
-            {{ range $name, $items := .Site.Taxonomies.categories }}
-                <li><a href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">{{ $name }} ({{ len $items }})</a></li>
+            {{ range first 5 .Site.Taxonomies.categories.ByCount }}
+                <li><a href="{{ $.Site.BaseURL }}categories/{{ .Name | urlize | lower }}">{{ .Name }} ({{ .Count }})</a></li>
             {{ end }}
         </ul>
 

--- a/layouts/partials/blogs/widgets/tags.html
+++ b/layouts/partials/blogs/widgets/tags.html
@@ -7,9 +7,10 @@
     </div>
 
     <div class="panel-body">
+
         <ul class="tag-cloud">
-            {{ range $name, $items := .Site.Taxonomies.tags }}
-                <li><a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower }}"><i class="fa fa-tags"></i> {{ $name }}</a></li>
+            {{ range first 10 .Site.Taxonomies.tags.ByCount }}
+                <li><a href="{{ $.Site.BaseURL }}tags/{{ .Name | urlize | lower }}"><i class="fa fa-tags"></i> {{ .Name }} ({{ .Count }})</a></li>
             {{ end }}
         </ul>
 

--- a/layouts/partials/events/widgets/tags.html
+++ b/layouts/partials/events/widgets/tags.html
@@ -8,8 +8,8 @@
 
     <div class="panel-body">
         <ul class="tag-cloud">
-            {{ range $name, $items := .Site.Taxonomies.event_tags }}
-                <li><a href="{{ $.Site.BaseURL }}event_tags/{{ $name | urlize | lower }}">{{ $name }} ({{ len $items }})</a></li>
+            {{ range first 10 .Site.Taxonomies.event_tags.ByCount }}
+                <li><a href="{{ $.Site.BaseURL }}tags/{{ .Name | urlize | lower }}"><i class="fa fa-tags"></i> {{ .Name }} ({{ .Count }})</a></li>
             {{ end }}
         </ul>
 


### PR DESCRIPTION
#65

今までの仕様だとタグとカテゴリをサイドバーに全部表示していたが、この仕様だとこれから記事が増えて行くごとにどんどん増えていってしまうので、カテゴリは上位5件をタグは上位10件のみを表示するようにした。

全てのタグやカテゴリを見るには、全てみるをクリックすればいいので、特に問題はないと思われる